### PR TITLE
Fix run code request to include match_id

### DIFF
--- a/src/pages/BattlePage.tsx
+++ b/src/pages/BattlePage.tsx
@@ -447,6 +447,7 @@ const BattlePage = () => {
     setRunStatus(null);
 
     try {
+      const matchId = localStorage.getItem('currentMatchId');
       const response = await authFetch(
         "http://localhost:8000/api/v1/game/submit",
         {
@@ -459,6 +460,7 @@ const BattlePage = () => {
             language: "python",
             code,
             problem_id: `${problemId}`,
+            match_id: matchId,
           }),
         },
       );

--- a/src/pages/MatchingPage.tsx
+++ b/src/pages/MatchingPage.tsx
@@ -51,6 +51,7 @@ const MatchingPage = () => {
         setOpponentAccepted(false);
         setAcceptTimeLeft(message.time_limit);
         matchIdRef.current = message.match_id;
+        localStorage.setItem('currentMatchId', String(message.match_id));
         // You might want to update opponent details here based on message.opponent_ids
       } else if (message.type === "match_accepted") {
         if (message.problem && message.game_id) {
@@ -72,6 +73,7 @@ const MatchingPage = () => {
         setUserAccepted(false);
         setOpponentAccepted(false);
         matchIdRef.current = null;
+        localStorage.removeItem('currentMatchId');
         if (message.reason === "timeout or rejection") {
           navigate("/home"); // Go back to home or a suitable page
         }
@@ -132,6 +134,7 @@ const MatchingPage = () => {
       const message = { type: "match_accept", match_id: matchIdRef.current };
       console.log("Sending WebSocket message:", message);
       ws.send(JSON.stringify(message));
+      localStorage.setItem('currentMatchId', String(matchIdRef.current));
     } else {
       console.warn(
         "WebSocket not connected or matchId not set. ws:",
@@ -149,6 +152,7 @@ const MatchingPage = () => {
         JSON.stringify({ type: "match_reject", match_id: matchIdRef.current }),
       );
     }
+    localStorage.removeItem('currentMatchId');
     navigate("/home"); // Navigate away after declining
   };
 
@@ -156,6 +160,7 @@ const MatchingPage = () => {
     if (ws) {
       ws.send(JSON.stringify({ type: "cancel_queue" }));
     }
+    localStorage.removeItem('currentMatchId');
     navigate("/home"); // Navigate away after cancelling
   };
 


### PR DESCRIPTION
## Summary
- persist `match_id` across screens during matchmaking
- send `match_id` in battle run API request

## Testing
- `npm run lint` *(fails: @typescript-eslint/no-explicit-any errors)*

------
https://chatgpt.com/codex/tasks/task_e_686b4b3e6144832e8d597d367ff96087