### PR TITLE
Add submission confirmation modal

### DIFF
--- a/src/components/SubmitConfirmModal.tsx
+++ b/src/components/SubmitConfirmModal.tsx
@@ -1,0 +1,37 @@
+import { AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent, AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle } from '@/components/ui/alert-dialog';
+import CyberButton from '@/components/CyberButton';
+
+interface SubmitConfirmModalProps {
+  isOpen: boolean;
+  onConfirm: () => void;
+  onCancel: () => void;
+}
+
+const SubmitConfirmModal: React.FC<SubmitConfirmModalProps> = ({ isOpen, onConfirm, onCancel }) => {
+  return (
+    <AlertDialog open={isOpen} onOpenChange={onCancel}>
+      <AlertDialogContent className="cyber-card border border-cyber-blue/20 bg-card/95 backdrop-blur-sm">
+        <AlertDialogHeader>
+          <AlertDialogTitle className="text-yellow-400">경고</AlertDialogTitle>
+          <AlertDialogDescription className="text-gray-300">
+            테스트케이스를 전부 통과하지 못했습니다. 그래도 제출하시겠습니까?
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter className="flex justify-center space-x-4">
+          <AlertDialogCancel asChild>
+            <CyberButton variant="secondary" onClick={onCancel} className="flex-1">
+              아니오
+            </CyberButton>
+          </AlertDialogCancel>
+          <AlertDialogAction asChild>
+            <CyberButton variant="destructive" onClick={onConfirm} className="flex-1">
+              예, 제출합니다
+            </CyberButton>
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+};
+
+export default SubmitConfirmModal;

--- a/src/pages/BattlePage.tsx
+++ b/src/pages/BattlePage.tsx
@@ -12,6 +12,7 @@ import { getLanguageConfig } from '@/utils/languageConfig';
 import { CodeEditorHandler } from '@/utils/codeEditorHandlers';
 import usePreventNavigation from '@/hooks/usePreventNavigation';
 import GameExitModal from '@/components/GameExitModal';
+import SubmitConfirmModal from '@/components/SubmitConfirmModal';
 import useWebSocketStore from '@/stores/websocketStore';
 import { authFetch } from '@/utils/api';
 import hljs from 'highlight.js/lib/core';
@@ -166,6 +167,7 @@ const BattlePage = () => {
   }, []);
   const chatEndRef = useRef<HTMLDivElement | null>(null);
   const [isExitModalOpen, setIsExitModalOpen] = useState(false);
+  const [isSubmitModalOpen, setIsSubmitModalOpen] = useState(false);
   const [confirmExitCallback, setConfirmExitCallback] = useState<(() => void) | null>(null);
   const [cancelExitCallback, setCancelExitCallback] = useState<(() => void) | null>(null);
 
@@ -554,8 +556,22 @@ const BattlePage = () => {
   };
 
   const handleSubmit = () => {
-    cleanupScreenShare(); // 코드 제출 시 화면 공유 중단
+    if (runStatus === '성공') {
+      cleanupScreenShare(); // 코드 제출 시 화면 공유 중단
+      navigate('/result');
+    } else {
+      setIsSubmitModalOpen(true);
+    }
+  };
+
+  const handleConfirmSubmit = () => {
+    setIsSubmitModalOpen(false);
+    cleanupScreenShare();
     navigate('/result');
+  };
+
+  const handleCancelSubmit = () => {
+    setIsSubmitModalOpen(false);
   };
 
   const toggleHint = () => {
@@ -921,6 +937,11 @@ const BattlePage = () => {
         isOpen={isExitModalOpen}
         onConfirmExit={handleConfirmExit}
         onCancelExit={handleCancelExit}
+      />
+      <SubmitConfirmModal
+        isOpen={isSubmitModalOpen}
+        onConfirm={handleConfirmSubmit}
+        onCancel={handleCancelSubmit}
       />
     </div>
   );


### PR DESCRIPTION
## Summary
- show SubmitConfirmModal when results didn't pass all test cases
- allow direct submission only when run status is success

## Testing
- `npm run lint` *(fails: no-empty-object-type and other pre-existing errors)*

------
https://chatgpt.com/codex/tasks/task_e_686b5792f01c832e8090e1c8e8bb447e