### PR TITLE
Refactor BattlePage layout

### DIFF
--- a/src/components/battle/BattleHeader.tsx
+++ b/src/components/battle/BattleHeader.tsx
@@ -1,0 +1,69 @@
+import CyberButton from '@/components/CyberButton';
+import { Clock, Flag, AlertTriangle, Monitor, LogOut } from 'lucide-react';
+
+interface BattleHeaderProps {
+  timeLeft: number;
+  isSolvingAlone: boolean;
+  isLocalStreamActive: boolean;
+  isRemoteStreamActive: boolean;
+  onSurrender: () => void;
+  onReport: () => void;
+  onLeave: () => void;
+  onStartScreenShare: () => void;
+}
+
+const BattleHeader = ({
+  timeLeft,
+  isSolvingAlone,
+  isLocalStreamActive,
+  isRemoteStreamActive,
+  onSurrender,
+  onReport,
+  onLeave,
+  onStartScreenShare,
+}: BattleHeaderProps) => {
+  return (
+    <header className="sticky top-0 z-50 cyber-card border-b border-cyber-blue/20 backdrop-blur-md">
+      <div className="container mx-auto px-4 py-3">
+        <div className="flex items-center justify-between">
+          <div className="flex items-center space-x-3">
+            <span className="text-xl font-bold neon-text">Codeground</span>
+          </div>
+          <div className="flex items-center space-x-2">
+            <Clock className="h-6 w-6 text-cyber-blue" />
+            <span className="text-2xl font-bold font-mono text-cyber-blue">
+              {`${Math.floor(timeLeft / 60)}:${(timeLeft % 60).toString().padStart(2, '0')}`}
+            </span>
+          </div>
+          <div className="flex items-center space-x-3">
+            {!isSolvingAlone && (
+              <CyberButton onClick={onSurrender} size="sm" variant="secondary">
+                <Flag className="mr-1 h-4 w-4" />
+                항복
+              </CyberButton>
+            )}
+            <CyberButton onClick={onReport} size="sm" variant="secondary">
+              <AlertTriangle className="mr-1 h-4 w-4" />
+              신고
+            </CyberButton>
+            {isSolvingAlone ? (
+              <CyberButton onClick={onLeave} size="sm">
+                <LogOut className="mr-1 h-4 w-4" />
+                나가기
+              </CyberButton>
+            ) : (
+              !isLocalStreamActive && !isRemoteStreamActive && (
+                <CyberButton onClick={onStartScreenShare} size="sm">
+                  <Monitor className="mr-1 h-4 w-4" />
+                  화면 공유 시작
+                </CyberButton>
+              )
+            )}
+          </div>
+        </div>
+      </div>
+    </header>
+  );
+};
+
+export default BattleHeader;

--- a/src/components/battle/ChatAndVideoSection.tsx
+++ b/src/components/battle/ChatAndVideoSection.tsx
@@ -1,0 +1,91 @@
+import CyberCard from '@/components/CyberCard';
+import { ScrollArea } from '@/components/ui/scroll-area';
+import { Monitor, Send } from 'lucide-react';
+import { useRef } from 'react';
+
+export interface ChatMessage {
+  user: string;
+  message: string;
+  type: 'chat' | 'system';
+}
+
+interface ChatAndVideoSectionProps {
+  chatMessages: ChatMessage[];
+  newMessage: string;
+  onMessageChange: (v: string) => void;
+  onSend: () => void;
+  chatEndRef: React.RefObject<HTMLDivElement>;
+  remoteVideoRef: React.RefObject<HTMLVideoElement>;
+  isRemoteStreamActive: boolean;
+  showRemoteScreenSharePrompt: boolean;
+  sharedRemoteStream: MediaStream | null;
+}
+
+const ChatAndVideoSection = ({
+  chatMessages,
+  newMessage,
+  onMessageChange,
+  onSend,
+  chatEndRef,
+  remoteVideoRef,
+  isRemoteStreamActive,
+  showRemoteScreenSharePrompt,
+  sharedRemoteStream,
+}: ChatAndVideoSectionProps) => {
+  return (
+    <div className="h-1/3 min-h-[16em] flex gap-2 mr-2">
+      <div className="flex-1 min-w-0">
+        <CyberCard className="p-3 flex flex-col h-full">
+          <h3 className="text-sm font-semibold text-cyber-blue mb-2">채팅</h3>
+          <ScrollArea className="flex-1 mb-2">
+            <div className="space-y-2 pr-3">
+              {chatMessages.map((msg, index) => (
+                <div
+                  key={index}
+                  className={`text-xs ${msg.type === 'system' ? 'text-red-400' : 'text-gray-400'}`}
+                >
+                  <div>
+                    {msg.user}: {msg.message}
+                  </div>
+                </div>
+              ))}
+              <div ref={chatEndRef} />
+            </div>
+          </ScrollArea>
+          <div className="flex">
+            <input
+              type="text"
+              value={newMessage}
+              onChange={(e) => onMessageChange(e.target.value)}
+              onKeyPress={(e) => e.key === 'Enter' && onSend()}
+              placeholder="메시지 입력..."
+              className="flex-1 text-xs bg-black/30 border border-gray-600 rounded-l px-2 py-1 text-white"
+            />
+            <button onClick={onSend} className="bg-cyber-blue px-2 py-1 rounded-r">
+              <Send className="h-3 w-3" />
+            </button>
+          </div>
+        </CyberCard>
+      </div>
+      <div className="flex-1 min-w-0">
+        <CyberCard className="p-3 flex flex-col items-center justify-center h-full">
+          {sharedRemoteStream && isRemoteStreamActive ? (
+            <video ref={remoteVideoRef} autoPlay playsInline className="w-full h-full object-contain" />
+          ) : (
+            <div className="text-xs text-gray-400 text-center">
+              <Monitor className="h-8 w-8 text-gray-400 mb-2 mx-auto" />
+              <div>상대방 화면</div>
+              {showRemoteScreenSharePrompt ? (
+                <div className="mt-1 text-red-400">공유 중지됨. 상대방이 다시 공유해야 합니다.</div>
+              ) : (
+                <div className="mt-1 text-yellow-400">공유 대기중...</div>
+              )}
+            </div>
+          )}
+        </CyberCard>
+      </div>
+    </div>
+  );
+};
+
+export default ChatAndVideoSection;

--- a/src/components/battle/CodeEditorSection.tsx
+++ b/src/components/battle/CodeEditorSection.tsx
@@ -1,0 +1,106 @@
+import CyberCard from '@/components/CyberCard';
+import CyberButton from '@/components/CyberButton';
+import { ResizablePanel, ResizablePanelGroup, ResizableHandle } from '@/components/ui/resizable';
+import { Play } from 'lucide-react';
+import { LanguageConfig } from '@/types/codeEditor';
+import { RefObject } from 'react';
+
+interface CodeEditorSectionProps {
+  languageConfig: LanguageConfig;
+  code: string;
+  onCodeChange: (v: string) => void;
+  onScroll: () => void;
+  onKeyDown: (e: React.KeyboardEvent<HTMLTextAreaElement>) => void;
+  lineNumbersRef: RefObject<HTMLDivElement>;
+  textareaRef: RefObject<HTMLTextAreaElement>;
+  highlightRef: RefObject<HTMLPreElement>;
+  displayLineCount: number;
+  isGamePaused: boolean;
+  onRun: () => void;
+  onSubmit: () => void;
+  executionResult: string;
+}
+
+const CodeEditorSection = ({
+  languageConfig,
+  code,
+  onCodeChange,
+  onScroll,
+  onKeyDown,
+  lineNumbersRef,
+  textareaRef,
+  highlightRef,
+  displayLineCount,
+  isGamePaused,
+  onRun,
+  onSubmit,
+  executionResult,
+}: CodeEditorSectionProps) => {
+  return (
+    <ResizablePanelGroup direction="vertical">
+      <ResizablePanel defaultSize={75} minSize={50}>
+        <CyberCard className="h-full flex flex-col ml-2 mb-1">
+          <div className="flex items-center px-3 py-1 border-b border-gray-700/50 bg-black/20">
+            <div className="text-xs text-gray-400">{languageConfig.name} Code Editor</div>
+          </div>
+          <div className="flex-1 overflow-hidden">
+            <div className="h-full flex bg-black/30">
+              <div ref={lineNumbersRef} className="flex-shrink-0 w-12 bg-black/20 border-r border-gray-700 overflow-hidden">
+                <div className="text-xs text-gray-500 leading-5 text-right py-3 px-2">
+                  {Array.from({ length: displayLineCount }, (_, i) => (
+                    <div key={i} className="h-5">{i + 1}</div>
+                  ))}
+                </div>
+              </div>
+              <div className="flex-1 overflow-hidden relative">
+                <pre
+                  ref={highlightRef}
+                  className="hljs pointer-events-none w-full h-full px-3 py-3 text-sm leading-5 font-mono whitespace-pre-wrap"
+                  style={{ fontFamily: languageConfig.fontFamily }}
+                />
+                <textarea
+                  ref={textareaRef}
+                  value={code}
+                  onChange={(e) => onCodeChange(e.target.value)}
+                  onScroll={onScroll}
+                  onKeyDown={onKeyDown}
+                  placeholder={languageConfig.placeholder}
+                  spellCheck={false}
+                  className="w-full h-full absolute top-0 left-0 bg-transparent px-3 py-3 font-mono resize-none focus:outline-none text-sm leading-5 border-none"
+                  style={{ fontFamily: languageConfig.fontFamily, tabSize: languageConfig.indentSize, color: 'transparent', caretColor: '#ffffff' }}
+                  readOnly={isGamePaused}
+                />
+              </div>
+            </div>
+          </div>
+        </CyberCard>
+      </ResizablePanel>
+      <ResizableHandle withHandle />
+      <ResizablePanel defaultSize={25} minSize={15}>
+        <CyberCard className="h-full flex flex-col ml-2 mt-1">
+          <div className="flex items-center justify-between px-3 py-1 border-b border-gray-700/50">
+            <h3 className="text-sm font-semibold text-cyber-blue">실행 결과</h3>
+            <div className="flex space-x-1">
+              <CyberButton onClick={onRun} size="sm" variant="secondary" className="px-6" disabled={isGamePaused}>
+                <Play className="mr-1 h-3 w-3" />
+                실행
+              </CyberButton>
+              <CyberButton onClick={onSubmit} size="sm" className="px-6" disabled={isGamePaused}>
+                제출
+              </CyberButton>
+            </div>
+          </div>
+          <div className="flex-1 p-2">
+            <div className="h-full bg-black/30 border border-gray-700 rounded p-3 overflow-auto">
+              <pre className="font-mono text-xs text-gray-300 whitespace-pre-wrap break-words">
+                {executionResult}
+              </pre>
+            </div>
+          </div>
+        </CyberCard>
+      </ResizablePanel>
+    </ResizablePanelGroup>
+  );
+};
+
+export default CodeEditorSection;

--- a/src/components/battle/ProblemSection.tsx
+++ b/src/components/battle/ProblemSection.tsx
@@ -1,0 +1,69 @@
+import CyberButton from '@/components/CyberButton';
+import CyberCard from '@/components/CyberCard';
+import { ScrollArea } from '@/components/ui/scroll-area';
+import { HelpCircle } from 'lucide-react';
+
+interface ProblemSectionProps {
+  problem: any;
+  showHint: boolean;
+  toggleHint: () => void;
+}
+
+const ProblemSection = ({ problem, showHint, toggleHint }: ProblemSectionProps) => {
+  return (
+    <div className="flex-1 mb-2">
+      <CyberCard className="h-[calc(100vh-24em)] p-4 mr-2 max-h-[860px]">
+        <ScrollArea className="h-full">
+          {problem ? (
+            <div className="space-y-4 pr-4">
+              <div className="flex items-start justify-between">
+                <div className="flex flex-col">
+                  <h1 className="text-xl font-bold neon-text">{problem.title}</h1>
+                </div>
+                <CyberButton onClick={toggleHint} size="sm" variant="secondary">
+                  <HelpCircle className="mr-1 h-4 w-4" />
+                  힌트
+                </CyberButton>
+              </div>
+              {showHint && problem.category && (
+                <div className="bg-yellow-500/10 border border-yellow-500/30 rounded-lg p-3">
+                  <h3 className="text-yellow-400 font-semibold mb-2">알고리즘 분류</h3>
+                  <div className="flex flex-wrap gap-2">
+                    {problem.category.map((tag: string, index: number) => (
+                      <span
+                        key={index}
+                        className="bg-yellow-500/20 text-yellow-300 px-2 py-1 rounded text-sm"
+                      >
+                        {tag}
+                      </span>
+                    ))}
+                  </div>
+                </div>
+              )}
+              <div>
+                <p className="text-gray-300 leading-relaxed">{problem.description}</p>
+              </div>
+              {problem.examples && (
+                <div>
+                  <h3 className="text-lg font-semibold text-cyber-blue mb-2">입출력 예</h3>
+                  <div className="bg-black/30 p-3 rounded-lg border border-gray-700 space-y-2">
+                    {problem.examples.map((example: any, index: number) => (
+                      <div key={index} className="font-mono text-sm">
+                        <div className="text-gray-400">{example.input}</div>
+                        <div className="text-green-400">{example.output}</div>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              )}
+            </div>
+          ) : (
+            <div className="text-center text-gray-400">문제 로딩 중...</div>
+          )}
+        </ScrollArea>
+      </CyberCard>
+    </div>
+  );
+};
+
+export default ProblemSection;

--- a/src/components/battle/index.ts
+++ b/src/components/battle/index.ts
@@ -1,0 +1,4 @@
+export { default as BattleHeader } from './BattleHeader';
+export { default as ProblemSection } from './ProblemSection';
+export { default as ChatAndVideoSection } from './ChatAndVideoSection';
+export { default as CodeEditorSection } from './CodeEditorSection';

--- a/src/pages/BattlePage.tsx
+++ b/src/pages/BattlePage.tsx
@@ -1,12 +1,9 @@
 import { useState, useEffect, useRef, useCallback } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 import { useUser } from '@/context/UserContext';
-import CyberCard from '@/components/CyberCard';
-import CyberButton from '@/components/CyberButton';
-import { Clock, Play, Send, Monitor, Flag, AlertTriangle, HelpCircle, LogOut } from 'lucide-react';
+import { BattleHeader, ProblemSection, ChatAndVideoSection, CodeEditorSection } from '@/components/battle';
 import { localStream as sharedLocalStream, remoteStream as sharedRemoteStream, setLocalStream, peerConnection as sharedPC, setPeerConnection, setRemoteStream } from '@/utils/webrtcStore';
 import { ResizablePanelGroup, ResizablePanel, ResizableHandle } from '@/components/ui/resizable';
-import { ScrollArea } from '@/components/ui/scroll-area';
 import { ProgrammingLanguage } from '@/types/codeEditor';
 import { getLanguageConfig } from '@/utils/languageConfig';
 import { CodeEditorHandler } from '@/utils/codeEditorHandlers';
@@ -732,219 +729,56 @@ const BattlePage = () => {
 
   return (
     <div ref={containerRef} className="min-h-screen cyber-grid bg-cyber-darker">
-      <header className="sticky top-0 z-50 cyber-card border-b border-cyber-blue/20 backdrop-blur-md">
-        <div className="container mx-auto px-4 py-3">
-          <div className="flex items-center justify-between">
-            <div className="flex items-center space-x-3">
-              <span className="text-xl font-bold neon-text">Codeground</span>
-            </div>
-            <div className="flex items-center space-x-2">
-              <Clock className={`h-6 w-6 text-cyber-blue`} />
-              <span className={`text-2xl font-bold font-mono text-cyber-blue`}>
-                {`${Math.floor(timeLeft / 60)}:${(timeLeft % 60).toString().padStart(2, '0')}`}
-              </span>
-            </div>
-            <div className="flex items-center space-x-3">
-              {!isSolvingAlone && (
-                <CyberButton onClick={handleSurrenderButtonClick} size="sm" variant="secondary">
-                  <Flag className="mr-1 h-4 w-4" />
-                  항복
-                </CyberButton>
-              )}
-              <CyberButton onClick={handleReportClick} size="sm" variant="secondary">
-                <AlertTriangle className="mr-1 h-4 w-4" />
-                신고
-              </CyberButton>
-              {isSolvingAlone ? (
-                <CyberButton onClick={handleSurrenderLeave} size="sm">
-                  <LogOut className="mr-1 h-4 w-4" />
-                  나가기
-                </CyberButton>
-              ) : (
-                (!isLocalStreamActive && !isRemoteStreamActive) && (
-                  <CyberButton onClick={startLocalScreenShare} size="sm">
-                    <Monitor className="mr-1 h-4 w-4" />
-                    화면 공유 시작
-                  </CyberButton>
-                )
-              )}
-            </div>
-          </div>
-        </div>
-      </header>
+
+      <BattleHeader
+        timeLeft={timeLeft}
+        isSolvingAlone={isSolvingAlone}
+        isLocalStreamActive={isLocalStreamActive}
+        isRemoteStreamActive={isRemoteStreamActive}
+        onSurrender={handleSurrenderButtonClick}
+        onReport={handleReportClick}
+        onLeave={handleSurrenderLeave}
+        onStartScreenShare={startLocalScreenShare}
+      />
 
       <main className="h-[calc(100vh-80px)] p-4">
         <ResizablePanelGroup direction="horizontal" className="h-full">
           <ResizablePanel defaultSize={40} minSize={30}>
             <div className="h-full flex flex-col">
-              <div className="flex-1 mb-2">
-                <CyberCard className="h-[calc(100vh-24em)] p-4 mr-2 max-h-[860px]">
-                  <ScrollArea className="h-full">
-                    {problem ? (
-                      <div className="space-y-4 pr-4">
-                        <div className="flex items-start justify-between">
-                          <div className="flex flex-col">
-                            <h1 className="text-xl font-bold neon-text">{problem.title}</h1>
-                            {/* {problemId && (
-                                <span className="text-[9px] text-gray-400 mt-1">ID: {problemId}</span>
-                            )} */}
-                          </div>
-                          <CyberButton onClick={toggleHint} size="sm" variant="secondary">
-                            <HelpCircle className="mr-1 h-4 w-4" />
-                            힌트
-                          </CyberButton>
-                        </div>
-                        {showHint && problem.category && (
-                          <div className="bg-yellow-500/10 border border-yellow-500/30 rounded-lg p-3">
-                            <h3 className="text-yellow-400 font-semibold mb-2">알고리즘 분류</h3>
-                            <div className="flex flex-wrap gap-2">
-                              {problem.category.map((tag, index) => (
-                                <span key={index} className="bg-yellow-500/20 text-yellow-300 px-2 py-1 rounded text-sm">
-                                  {tag}
-                                </span>
-                              ))}
-                            </div>
-                          </div>
-                        )}
-                        <div>
-                          <p className="text-gray-300 leading-relaxed">{problem.description}</p>
-                        </div>
-                        {problem.examples && (
-                          <div>
-                            <h3 className="text-lg font-semibold text-cyber-blue mb-2">입출력 예</h3>
-                            <div className="bg-black/30 p-3 rounded-lg border border-gray-700 space-y-2">
-                              {problem.examples.map((example, index) => (
-                                <div key={index} className="font-mono text-sm">
-                                  <div className="text-gray-400">{example.input}</div>
-                                  <div className="text-green-400">{example.output}</div>
-                                </div>
-                              ))}
-                            </div>
-                          </div>
-                        )}
-                      </div>
-                    ) : (
-                      <div className="text-center text-gray-400">문제 로딩 중...</div>
-                    )}
-                  </ScrollArea>
-                </CyberCard>
-              </div>
-              <div className="h-1/3 min-h-[16em] flex gap-2 mr-2">
-                <div className="flex-1 min-w-0">
-                  <CyberCard className="p-3 flex flex-col h-full">
-                    <h3 className="text-sm font-semibold text-cyber-blue mb-2">채팅</h3>
-                    <ScrollArea className="flex-1 mb-2">
-                      <div className="space-y-2 pr-3">
-                        {chatMessages.map((msg, index) => (
-                          <div key={index} className={`text-xs ${msg.type === 'system' ? 'text-red-400' : 'text-gray-400'}`}>
-                            <div>
-                              {msg.user}: {msg.message}
-                            </div>
-                          </div>
-                        ))}
-                        <div ref={chatEndRef} />
-                      </div>
-                    </ScrollArea>
-                    <div className="flex">
-                      <input
-                        type="text"
-                        value={newMessage}
-                        onChange={(e) => setNewMessage(e.target.value)}
-                        onKeyPress={(e) => e.key === "Enter" && handleSendMessage()}
-                        placeholder="메시지 입력..."
-                        className="flex-1 text-xs bg-black/30 border border-gray-600 rounded-l px-2 py-1 text-white"
-                      />
-                      <button onClick={handleSendMessage} className="bg-cyber-blue px-2 py-1 rounded-r">
-                        <Send className="h-3 w-3" />
-                      </button>
-                    </div>
-                  </CyberCard>
-                </div>
-                <div className="flex-1 min-w-0">
-                  <CyberCard className="p-3 flex flex-col items-center justify-center h-full">
-                    {sharedRemoteStream && isRemoteStreamActive ? (
-                      <video ref={remoteVideoRef} autoPlay playsInline className="w-full h-full object-contain" />
-                    ) : (
-                      <div className="text-xs text-gray-400 text-center">
-                        <Monitor className="h-8 w-8 text-gray-400 mb-2 mx-auto" />
-                        <div>상대방 화면</div>
-                        {showRemoteScreenSharePrompt ? (
-                          <div className="mt-1 text-red-400">공유 중지됨. 상대방이 다시 공유해야 합니다.</div>
-                        ) : (
-                          <div className="mt-1 text-yellow-400">공유 대기중...</div>
-                        )}
-                      </div>
-                    )}
-                  </CyberCard>
-                </div>
-              </div>
+              <ProblemSection problem={problem} showHint={showHint} toggleHint={toggleHint} />
+              <ChatAndVideoSection
+                chatMessages={chatMessages}
+                newMessage={newMessage}
+                onMessageChange={setNewMessage}
+                onSend={handleSendMessage}
+                chatEndRef={chatEndRef}
+                remoteVideoRef={remoteVideoRef}
+                isRemoteStreamActive={isRemoteStreamActive}
+                showRemoteScreenSharePrompt={showRemoteScreenSharePrompt}
+                sharedRemoteStream={sharedRemoteStream}
+              />
             </div>
           </ResizablePanel>
           <ResizableHandle withHandle />
           <ResizablePanel defaultSize={60} minSize={40}>
-            <ResizablePanelGroup direction="vertical">
-              <ResizablePanel defaultSize={75} minSize={50}>
-                <CyberCard className="h-full flex flex-col ml-2 mb-1">
-                  <div className="flex items-center px-3 py-1 border-b border-gray-700/50 bg-black/20">
-                    <div className="text-xs text-gray-400">{languageConfig.name} Code Editor</div>
-                  </div>
-                  <div className="flex-1 overflow-hidden">
-                    <div className="h-full flex bg-black/30">
-                      <div ref={lineNumbersRef} className="flex-shrink-0 w-12 bg-black/20 border-r border-gray-700 overflow-hidden">
-                        <div className="text-xs text-gray-500 leading-5 text-right py-3 px-2">
-                          {Array.from({ length: displayLineCount }, (_, i) => (
-                            <div key={i} className="h-5">{i + 1}</div>
-                          ))}
-                        </div>
-                      </div>
-                      <div className="flex-1 overflow-hidden relative">
-                        <pre ref={highlightRef} className="hljs pointer-events-none w-full h-full px-3 py-3 text-sm leading-5 font-mono whitespace-pre-wrap" style={{ fontFamily: languageConfig.fontFamily }} />
-                        <textarea
-                          ref={textareaRef}
-                          value={code}
-                          onChange={(e) => setCode(e.target.value)}
-                          onScroll={handleScroll}
-                          onKeyDown={handleKeyDown}
-                          placeholder={languageConfig.placeholder}
-                          spellCheck={false}
-                          className="w-full h-full absolute top-0 left-0 bg-transparent px-3 py-3 font-mono resize-none focus:outline-none text-sm leading-5 border-none"
-                          style={{ fontFamily: languageConfig.fontFamily, tabSize: languageConfig.indentSize, color: 'transparent', caretColor: '#ffffff' }}
-                          readOnly={isGamePaused}
-                        />
-                      </div>
-                    </div>
-                  </div>
-                </CyberCard>
-              </ResizablePanel>
-              <ResizableHandle withHandle />
-              <ResizablePanel defaultSize={25} minSize={15}>
-                <CyberCard className="h-full flex flex-col ml-2 mt-1">
-                  <div className="flex items-center justify-between px-3 py-1 border-b border-gray-700/50">
-                    <h3 className="text-sm font-semibold text-cyber-blue">실행 결과</h3>
-                    <div className="flex space-x-1">
-                      <CyberButton onClick={handleRun} size="sm" variant="secondary" className="px-6" disabled={isGamePaused}>
-                        <Play className="mr-1 h-3 w-3" />
-                        실행
-                      </CyberButton>
-                      <CyberButton onClick={handleSubmit} size="sm" className="px-6" disabled={isGamePaused}>
-                        제출
-                      </CyberButton>
-                    </div>
-                  </div>
-                  <div className="flex-1 p-2">
-                    <div className="h-full bg-black/30 border border-gray-700 rounded p-3 overflow-auto">
-                      <pre className="font-mono text-xs text-gray-300 whitespace-pre-wrap break-words">
-                        {executionResult}
-                      </pre>
-                    </div>
-                  </div>
-                </CyberCard>
-              </ResizablePanel>
-            </ResizablePanelGroup>
+            <CodeEditorSection
+              languageConfig={languageConfig}
+              code={code}
+              onCodeChange={setCode}
+              onScroll={handleScroll}
+              onKeyDown={handleKeyDown}
+              lineNumbersRef={lineNumbersRef}
+              textareaRef={textareaRef}
+              highlightRef={highlightRef}
+              displayLineCount={displayLineCount}
+              isGamePaused={isGamePaused}
+              onRun={handleRun}
+              onSubmit={handleSubmit}
+              executionResult={executionResult}
+            />
           </ResizablePanel>
         </ResizablePanelGroup>
       </main>
-
       <GameExitModal
         isOpen={isExitModalOpen}
         onConfirmExit={handleConfirmExit}


### PR DESCRIPTION
## Summary
- extract BattleHeader, ProblemSection, ChatAndVideoSection, and CodeEditorSection components
- simplify BattlePage by using newly created components

## Testing
- `npm run lint` *(fails: Unexpected any, etc.)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686b8ad772f8832e89ff54bd7282f3a2