### PR TITLE
Fix countdown progress bar start

### DIFF
--- a/src/pages/ScreenShareSetupPage.tsx
+++ b/src/pages/ScreenShareSetupPage.tsx
@@ -584,7 +584,7 @@ const ScreenShareSetupPage = () => {
               <div
                 className="h-full bg-gradient-to-r from-cyber-blue to-cyber-purple rounded-full transition-all duration-1000 ease-linear"
                 style={{
-                  width: `${((4 - countdown) / 3) * 100}%`,
+                  width: `${((3 - countdown) / 3) * 100}%`,
                   boxShadow: "0 0 10px rgba(0, 200, 255, 0.5)",
                 }}
               />


### PR DESCRIPTION
## Summary
- progress bar for countdown should start from 0% when count is 3

## Testing
- `npm run lint` *(fails: @typescript-eslint/no-require-imports in tailwind.config.ts)*

------
https://chatgpt.com/codex/tasks/task_e_687f19d13178832eb801760c877db354